### PR TITLE
Version 2.0.0

### DIFF
--- a/.changeset/fluffy-banks-clean.md
+++ b/.changeset/fluffy-banks-clean.md
@@ -1,0 +1,5 @@
+---
+"@sv443-network/coreutils": minor
+---
+
+Added `overflowVal()` to conform a value to an over- & undeflowing range

--- a/.changeset/great-cups-buy.md
+++ b/.changeset/great-cups-buy.md
@@ -1,0 +1,5 @@
+---
+"@sv443-network/coreutils": minor
+---
+
+Added optional abstract method `DataStoreEngine.deleteStorage()` for deleting the data storage container itself

--- a/.changeset/great-cups-buy.md
+++ b/.changeset/great-cups-buy.md
@@ -2,4 +2,4 @@
 "@sv443-network/coreutils": minor
 ---
 
-Added optional abstract method `DataStoreEngine.deleteStorage()` for deleting the data storage container itself. If implemented, it will be called from the method `DataStore.deleteData()`
+Added optional abstract method `DataStoreEngine.deleteStorage()` for deleting the data storage container itself. If implemented in subclasses, it will be called from the method `DataStore.deleteData()`

--- a/.changeset/great-cups-buy.md
+++ b/.changeset/great-cups-buy.md
@@ -2,4 +2,4 @@
 "@sv443-network/coreutils": minor
 ---
 
-Added optional abstract method `DataStoreEngine.deleteStorage()` for deleting the data storage container itself
+Added optional abstract method `DataStoreEngine.deleteStorage()` for deleting the data storage container itself. If implemented, it will be called from the method `DataStore.deleteData()`

--- a/.changeset/pink-readers-rest.md
+++ b/.changeset/pink-readers-rest.md
@@ -1,0 +1,5 @@
+---
+"@sv443-network/coreutils": minor
+---
+
+Added `dataStoreOptions` constructor prop to the DataStoreEngine subclasses to enable them to be used standalone.

--- a/.changeset/stale-pianos-enjoy.md
+++ b/.changeset/stale-pianos-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@sv443-network/coreutils": minor
+---
+
+Added method `NanoEmitter.onMulti()` to listen to when multiple events have emitted, with fine grained options

--- a/.changeset/tidy-needles-ask.md
+++ b/.changeset/tidy-needles-ask.md
@@ -3,4 +3,6 @@
 ---
 
 Removed the boolean property `__ds-${id}-enc` from the `DataStore` and `DataStoreEngine` classes.  
-Now the key `__ds-${id}-enf` will hold the encoding format identifier string, or `null` if not set.
+Now the key `__ds-${id}-enf` will hold the encoding format identifier string, or `null` if not set.  
+This will make it possible to switch the encoding format without compatibility issues.  
+This functionality is not officially supported yet, but can be achieved manually by calling the storage API methods of `storeInstance.engine`

--- a/.changeset/tidy-needles-ask.md
+++ b/.changeset/tidy-needles-ask.md
@@ -1,0 +1,6 @@
+---
+"@sv443-network/coreutils": major
+---
+
+Removed the boolean property `__ds-${id}-enc` from the `DataStore` and `DataStoreEngine` classes.  
+Now the key `__ds-${id}-enf` will hold the encoding format identifier string, or `null` if not set.

--- a/.changeset/tidy-needles-ask.md
+++ b/.changeset/tidy-needles-ask.md
@@ -3,6 +3,6 @@
 ---
 
 Removed the boolean property `__ds-${id}-enc` from the `DataStore` and `DataStoreEngine` classes.  
-Now the key `__ds-${id}-enf` will hold the encoding format identifier string, or `null` if not set.  
+Now the key `__ds-${id}-enf` will hold the encoding format identifier string, or `null` if not set (will get created on the next write call).  
 This will make it possible to switch the encoding format without compatibility issues.  
 This functionality is not officially supported yet, but can be achieved manually by calling the storage API methods of `storeInstance.engine`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ Parts of the code have been overhauled, and some features have been added:
   - Added [`truncStr()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-truncstr) to truncate a string to a given length, optionally adding an ellipsis.
   - Added [`valsWithin()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-valswithin) to check if two values, rounded at the given decimal, are within a certain range of each other.
   - Added [`scheduleExit()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-scheduleexit) to schedule a Node/Deno process to exit with the given code, after the microtask queue is empty or after the given timeout.
-  - Added [`overflowVal()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-overflowval) to conform a value to an over- & underflowing range.
-  - Added [`NanoEmitter.onMulti()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#nanoemitteronmulti) to listen for multiple events at once, with the option to specify if any or all of the events should be emitted before calling the callback.
 - **BREAKING CHANGES:**
   - Reworked `DataStore`
     - The constructor now needs an `engine` property that is an instance of a [`DataStoreEngine`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#class-datastoreengine.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Parts of the code have been overhauled, and some features have been added:
   - Added [`truncStr()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-truncstr) to truncate a string to a given length, optionally adding an ellipsis.
   - Added [`valsWithin()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-valswithin) to check if two values, rounded at the given decimal, are within a certain range of each other.
   - Added [`scheduleExit()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-scheduleexit) to schedule a Node/Deno process to exit with the given code, after the microtask queue is empty or after the given timeout.
+  - Added [`overflowVal()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-overflowval) to conform a value to an over- & underflowing range.
   - Added [`NanoEmitter.onMulti()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#nanoemitteronmulti) to listen for multiple events at once, with the option to specify if any or all of the events should be emitted before calling the callback.
 - **BREAKING CHANGES:**
   - Reworked `DataStore`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Parts of the code have been overhauled, and some features have been added:
   - Added [`truncStr()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-truncstr) to truncate a string to a given length, optionally adding an ellipsis.
   - Added [`valsWithin()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-valswithin) to check if two values, rounded at the given decimal, are within a certain range of each other.
   - Added [`scheduleExit()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#function-scheduleexit) to schedule a Node/Deno process to exit with the given code, after the microtask queue is empty or after the given timeout.
+  - Added [`NanoEmitter.onMulti()`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#nanoemitteronmulti) to listen for multiple events at once, with the option to specify if any or all of the events should be emitted before calling the callback.
 - **BREAKING CHANGES:**
   - Reworked `DataStore`
     - The constructor now needs an `engine` property that is an instance of a [`DataStoreEngine`](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#class-datastoreengine.)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Intended to be used in conjunction with [`@sv443-network/userutils`](https://git
     - 🟩 [`const defaultPbChars`](./docs.md#const-defaultpbchars) - Default characters for the progress bar
     - 🔷 [`type ProgressBarChars`](./docs.md#type-progressbarchars) - Type for the progress bar characters object
   - 🟣 [`function joinArrayReadable()`](./docs.md#function-joinarrayreadable) - Joins the given array into a string, using the given separators and last separator
-  - 🟣 [`function secsToTimeStr()`](./docs.md#function-sectostimestr) - Turns the given number of seconds into a string in the format `(hh:)mm:ss` with intelligent zero-padding
+  - 🟣 [`function secsToTimeStr()`](./docs.md#function-secstotimestr) - Turns the given number of seconds into a string in the format `(hh:)mm:ss` with intelligent zero-padding
   - 🟣 [`function truncStr()`](./docs.md#function-truncstr) - Truncates the given string to the given length
 <!-- - *[**TieredCache:**](./docs.md#tieredcache)
   - 🟧 *[`class TieredCache`](./docs.md#class-tieredcache) - A multi-tier cache that uses multiple storage engines with different expiration times
@@ -135,11 +135,11 @@ yarn add @sv443-network/coreutils
 npx jsr install @sv443-network/coreutils
 deno add jsr:@sv443-network/coreutils
 ```
-- If you are in a DOM environment, you can include the UMD bundle using your favorite CDN:
+- If you are in a DOM environment, you can include the UMD bundle using your favorite CDN (after inserting the version number):
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@sv443-network/coreutils@latest/dist/CoreUtils.min.umd.js"></script>
-<script src="https://unpkg.com/@sv443-network/coreutils@latest/dist/CoreUtils.min.umd.js"></script>
-<script src="https://esm.sh/@sv443-network/coreutils@latest/dist/CoreUtils.min.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@sv443-network/coreutils@INSERT_VERSION_HERE/dist/CoreUtils.min.umd.js"></script>
+<script src="https://unpkg.com/@sv443-network/coreutils@INSERT_VERSION_HERE/dist/CoreUtils.min.umd.js"></script>
+<script src="https://esm.sh/@sv443-network/coreutils@INSERT_VERSION_HERE/dist/CoreUtils.min.umd.js"></script>
 ```
 - Then, import parts of the library as needed:
 ```ts

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Intended to be used in conjunction with [`@sv443-network/userutils`](https://git
   - 🟣 [`function formatNumber()`](./docs.md#function-formatnumber) - Formats a number to a string using the given locale and format identifier
     - 🔷 [`type NumberFormat`](./docs.md#type-numberformat) - Number format identifier
   - 🟣 [`function mapRange()`](./docs.md#function-maprange) - Maps a number from one range to another
+  - 🟣 [`function overflowVal()`](./docs.md#function-overflowVal) - Makes sure a number is in a range by over- & underflowing it
   - 🟣 [`function randRange()`](./docs.md#function-randrange) - Returns a random number in the given range
   - 🟣 [`function roundFixed()`](./docs.md#function-roundfixed) - Rounds the given number to the given number of decimal places
   - 🟣 [`function valsWithin()`](./docs.md#function-valswithin) - Checks if the given numbers are within a certain range of each other
@@ -168,3 +169,15 @@ const CoreUtils = require("@sv443-network/coreutils");
 // - or import the library on your HTML page:
 // <script src="https://cdn.jsdelivr.net/npm/@sv443-network/coreutils@latest/dist/CoreUtils.min.umd.js"></script>
 ```
+
+<br><br>
+
+<div align="center" style="text-align: center;">
+
+Made with ❤️ by [Sv443](https://github.com/Sv443)  
+If you like this userscript, please consider [supporting the development](https://github.com/sponsors/Sv443)  
+  
+© 2025 Sv443 & Sv443 Network  
+[MIT license](./LICENSE.txt)
+
+</div>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Cross-platform, general-purpose, JavaScript core library for Node, Deno and the browser.  
 Intended to be used in conjunction with [`@sv443-network/userutils`](https://github.com/Sv443-Network/UserUtils) and [`@sv443-network/djsutils`](https://github.com/Sv443-Network/DJSUtils), but can be used independently as well.
 
-### [Documentation](./docs.md#readme) &bull; [Features](#features) &bull; [Installation](#installation) &bull; [License](#license) &bull; [Changelog](./CHANGELOG.md)
+### [Documentation](./docs.md#readme) &bull; [Features](#features) &bull; [Installation](#installation) &bull; [License](./LICENSE.txt) &bull; [Changelog](./CHANGELOG.md)
 
 </div>
 <br>

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Intended to be used in conjunction with [`@sv443-network/userutils`](https://git
 > 🟣 = function  
 > 🟧 = class  
 > 🔷 = type  
-> 🔶 = const
+> 🟩 = const
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Intended to be used in conjunction with [`@sv443-network/userutils`](https://git
     - 🔷 [`type DataStoreData`](./docs.md#type-datastoredata) - The type of the serializable data
   - 🟧 [`class DataStoreSerializer`](./docs.md#class-datastoreserializer) - Serializes and deserializes data for multiple DataStore instances
     - 🔷 [`type DataStoreSerializerOptions`](./docs.md#type-datastoreserializeroptions) - Options for the DataStoreSerializer
-    - 🔷 [`type LoadStoresDataResult`](./docs.md#type-loadstoresdataresult) - Result of calling [`loadStoresData()`](#datastoreserializer-loadstoresdata)
+    - 🔷 [`type LoadStoresDataResult`](./docs.md#type-loadstoresdataresult) - Result of calling [`loadStoresData()`](./docs.md#datastoreserializer-loadstoresdata)
     - 🔷 [`type SerializedDataStore`](./docs.md#type-serializeddatastore) - Meta object and serialized data of a DataStore instance
     - 🔷 [`type StoreFilter`](./docs.md#type-storefilter) - Filter for selecting data stores
   - 🟧 [`class DataStoreEngine`](./docs.md#class-datastoreengine) - Base class for DataStore storage engines, which handle the data storage
-    - 🔷 [`type DataStoreEngineDSOptions`](./docs.md#type-datastoreenginedsoptions) - Reduced version of [`DataStoreOptions`](#type-datastoreoptions)
+    - 🔷 [`type DataStoreEngineDSOptions`](./docs.md#type-datastoreenginedsoptions) - Reduced version of [`DataStoreOptions`](./docs.md#type-datastoreoptions)
   - [Storage Engines:](./docs.md#storage-engines)
     - 🟧 [`class BrowserStorageEngine`](./docs.md#class-browserstorageengine) - Storage engine for browser environments (localStorage, sessionStorage)
       - 🔷 [`type BrowserStorageEngineOptions`](./docs.md#browserstorageengineoptions) - Options for the browser storage engine
@@ -167,7 +167,8 @@ const CoreUtils = require("@sv443-network/coreutils");
 // - to make the global variable `CoreUtils` available, import this file:
 // "@sv443-network/coreutils/dist/CoreUtils.min.umd.js"
 // - or import the library on your HTML page:
-// <script src="https://cdn.jsdelivr.net/npm/@sv443-network/coreutils@latest/dist/CoreUtils.min.umd.js"></script>
+// <script src="https://cdn.jsdelivr.net/npm/@sv443-network/coreutils@INSERT_VERSION_HERE/dist/CoreUtils.min.umd.js"></script>
+// (make sure to insert the version number above. Use 'latest' (not recommended) or a specific version, e.g. '9.4.3')
 ```
 
 <br><br>

--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ Intended to be used in conjunction with [`@sv443-network/userutils`](https://git
   - 🟧 [`class DataStore`](./docs.md#class-datastore) - The main class for the data store
     - 🔷 [`type DataStoreOptions`](./docs.md#type-datastoreoptions) - Options for the data store
     - 🔷 [`type DataMigrationsDict`](./docs.md#type-datamigrationsdict) - Dictionary of data migration functions
+    - 🔷 [`type DataStoreData`](./docs.md#type-datastoredata) - The type of the serializable data
   - 🟧 [`class DataStoreSerializer`](./docs.md#class-datastoreserializer) - Serializes and deserializes data for multiple DataStore instances
     - 🔷 [`type DataStoreSerializerOptions`](./docs.md#type-datastoreserializeroptions) - Options for the DataStoreSerializer
-    - 🔷 [`type LoadStoresDataResult`](./docs.md#type-loadstoresdataresult) - Result of calling [`loadStoresData()`](./docs.md#datastoreserializer-loadstoresdata)
+    - 🔷 [`type LoadStoresDataResult`](./docs.md#type-loadstoresdataresult) - Result of calling [`loadStoresData()`](#datastoreserializer-loadstoresdata)
     - 🔷 [`type SerializedDataStore`](./docs.md#type-serializeddatastore) - Meta object and serialized data of a DataStore instance
     - 🔷 [`type StoreFilter`](./docs.md#type-storefilter) - Filter for selecting data stores
   - 🟧 [`class DataStoreEngine`](./docs.md#class-datastoreengine) - Base class for DataStore storage engines, which handle the data storage
+    - 🔷 [`type DataStoreEngineDSOptions`](./docs.md#type-datastoreenginedsoptions) - Reduced version of [`DataStoreOptions`](#type-datastoreoptions)
   - [Storage Engines:](./docs.md#storage-engines)
     - 🟧 [`class BrowserStorageEngine`](./docs.md#class-browserstorageengine) - Storage engine for browser environments (localStorage, sessionStorage)
       - 🔷 [`type BrowserStorageEngineOptions`](./docs.md#browserstorageengineoptions) - Options for the browser storage engine

--- a/docs.md
+++ b/docs.md
@@ -267,7 +267,7 @@ Signature:
 takeRandomItemIndex<TItem = unknown>(arr: TItem[]): [item?: TItem, index?: number];
 ```
   
-Returns a random item and its index as a tuple from the given array and mutates the original array to remove it.  
+Returns a random item and its original index as a tuple from the given array and mutates the original array to remove it.  
 If the array is empty, `undefined` will be returned for both values.  
   
 <details><summary>Example - click to view</summary>
@@ -277,14 +277,14 @@ import { takeRandomItemIndex } from "@sv443-network/coreutils";
 
 const arr = ["foo", "bar", "baz"];
 
-console.log(takeRandomItemIndex(arr)); // ["bar", 1]
-console.log(arr); // ["foo", "baz"]
+while([itm, idx] = takeRandomItemIndex(arr), itm !== undefined) {
+  console.log(idx, itm, arr);
+}
 
-console.log(takeRandomItemIndex(arr)); // ["baz", 1]
-console.log(arr); // ["foo"]
-
-console.log(takeRandomItemIndex(arr)); // ["foo", 0]
-console.log(arr); // []
+// Logs:
+// 1 "bar" ["foo", "baz"]
+// 1 "baz" ["foo"]
+// 0 "foo" []
 
 console.log(takeRandomItemIndex(arr)); // [undefined, undefined]
 console.log(arr); // []
@@ -542,7 +542,7 @@ This randomization is also affected by the `enhancedEntropy` setting, unless the
   
 Throws a RangeError if the length is less than 1 or the radix is less than 2 or greater than 36.  
   
-⚠️ This is not suitable for generating anything related to cryptography! Use [SubtleCrypto's `generateKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey) for that instead.  
+- ⚠️ This is not suitable for generating anything related to cryptography! Use [SubtleCrypto's `generateKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey) for that instead.  
   
 <details><summary>Example - click to view</summary>
 
@@ -612,7 +612,7 @@ It combines the data of multiple DataStore instances into a single object that c
   
 If you were using the `DataStore` class from the `@sv443-network/coreutils` package before, all your data should be migrated automatically on the first call to `loadData()`.  
   
-⚠️ The data is serialized as a JSON string, so only JSON-compatible data can be used. Circular structures and complex objects (containing functions, symbols, etc.) will either throw an error on load and save or cause otherwise unexpected behavior. Properties with a value of `undefined` will be removed from the data prior to saving it, so use `null` instead.  
+- ⚠️ The data is serialized as a JSON string, so only JSON-compatible data can be used. Circular structures and complex objects (containing functions, symbols, etc.) will either throw an error on load and save or cause otherwise unexpected behavior. Properties with a value of `undefined` will be removed from the data prior to saving it, so use `null` instead.  
   
 <details><summary><b>Example - click to view</b></summary>
 
@@ -868,7 +868,7 @@ Also, by default a checksum is calculated and importing data with a mismatching 
   
 The class' internal methods are all declared as protected, so you can extend this class and override them if you need to add your own functionality.  
   
-⚠️ Needs to run in a secure context (HTTPS) due to the use of the SubtleCrypto API.  
+- ⚠️ Needs to run in a secure context (HTTPS) due to the use of the SubtleCrypto API.  
   
 <details><summary><b>Example - click to view</b></summary>
 
@@ -1375,8 +1375,8 @@ const engine = new BrowserStorageEngine(options?: BrowserStorageEngineOptions);
   
 Storage engine for the [`DataStore` class](#class-datastore) that uses the browser's LocalStorage or SessionStorage to store data.  
   
-⚠️ Requires a secure DOM environment (HTTPS)  
-⚠️ Don't reuse this engine across multiple [`DataStore`](#class-datastore) instances
+- ⚠️ Requires a secure DOM environment (HTTPS)  
+- ⚠️ Don't reuse engines across multiple [`DataStore`](#class-datastore) instances
   
 <details><summary>Example - click to view</summary>
 
@@ -1441,8 +1441,8 @@ const engine = new FileStorageEngine(options?: FileStorageEngineOptions);
   
 Storage engine for the [`DataStore` class](#class-datastore) that uses a file to store data.  
   
-⚠️ Requires Node.js or Deno with Node compatibility (v1.31+)  
-⚠️ Don't reuse this engine across multiple [`DataStore`](#class-datastore) instances  
+- ⚠️ Requires Node.js or Deno with Node compatibility (v1.31+)  
+- ⚠️ Don't reuse engines across multiple [`DataStore`](#class-datastore) instances  
   
 <details><summary>Example - click to view</summary>
 

--- a/docs.md
+++ b/docs.md
@@ -2799,21 +2799,25 @@ doStuff();
 ### `NanoEmitter.on()`  
 Signature:
 ```ts
-NanoEmitter.on<K extends keyof TEventMap>(event: K, listener: TEventMap[K]): void
+NanoEmitter.on<K extends keyof TEventMap>(event: K, listener: TEventMap[K]): () => void
 ```
   
 Registers a listener function for the given event.  
-May be called multiple times for the same event.
+May be called multiple times for the same event.  
+  
+Returns a function that can be called to unsubscribe the listener from the event.
   
 <br>
 
 ### `NanoEmitter.once()`
 Signature:
 ```ts
-NanoEmitter.once<K extends keyof TEventMap>(event: K, listener: TEventMap[K]): void
+NanoEmitter.once<K extends keyof TEventMap>(event: K, listener: TEventMap[K]): () => void
 ```
   
-Registers a listener function for the given event that will only be called once.
+Registers a listener function for the given event that will only be called once.  
+  
+Returns a function that can be called to unsubscribe the listener from the event.
 
 <br>
 

--- a/docs.md
+++ b/docs.md
@@ -399,10 +399,10 @@ console.log(rgbToHex());                                // #nannannan
 ### `function abtoa()`
 Signature:
 ```ts
-function abtoa(buf: ArrayBuffer): string;
+function abtoa(buf: Uint8Array): string;
 ```
   
-Converts an ArrayBuffer to a base64-encoded (ASCII) string.  
+Converts an ArrayBuffer (Uint8Array) to a base64-encoded (ASCII) string.  
 Used to encode a value to be later decoded with the [`atoab()` function](#function-atoab).  
   
 <details><summary>Example - click to view</summary>
@@ -413,7 +413,7 @@ import { abtoa } from "@sv443-network/coreutils";
 const buffer = new ArrayBuffer(8);
 const view = new Uint8Array(buffer);
 view.set([1, 2, 3, 4, 5, 6, 7, 8]);
-const base64 = abtoa(buffer);
+const base64 = abtoa(view);
 console.log(base64); // AQIDBAUGBwg=
 ```
 </details>
@@ -423,10 +423,10 @@ console.log(base64); // AQIDBAUGBwg=
 ### `function atoab()`
 Signature:
 ```ts
-function atoab(str: string): ArrayBuffer;
+function atoab(str: string): Uint8Array;
 ```
   
-Converts a base64-encoded (ASCII) string to an ArrayBuffer.  
+Converts a base64-encoded (ASCII) string to an ArrayBuffer (Uint8Array).  
 Used to decode a value previously encoded with the [`abtoa()` function](#function-abtoa).  
   
 <details><summary>Example - click to view</summary>
@@ -436,8 +436,7 @@ import { atoab } from "@sv443-network/coreutils";
 
 const base64 = "AQIDBAUGBwg="; // see abtoa() example
 const buffer = atoab(base64);
-const view = new Uint8Array(buffer);
-console.log(view); // Uint8Array(8) [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+console.log(buffer); // Uint8Array(8) [ 1, 2, 3, 4, 5, 6, 7, 8 ]
 ```
 </details>
 
@@ -446,13 +445,13 @@ console.log(view); // Uint8Array(8) [ 1, 2, 3, 4, 5, 6, 7, 8 ]
 ### `function compress()`
 Signature:
 ```ts
-function compress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<ArrayBuffer | string>;
+function compress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<Uint8Array | string>;
 ```
   
-Compresses the given string or ArrayBuffer using the given algorithm and encoding.  
-The `input` argument can be a [`Stringifiable`](#type-stringifiable) object or an ArrayBuffer.  
+Compresses the given string or ArrayBuffer (Uint8Array) using the given algorithm and encoding.  
+The `input` argument can be a [`Stringifiable`](#type-stringifiable) object or an ArrayBuffer (Uint8Array).  
 The `compressionFormat` argument can usually be either `gzip`, `deflate` or `deflate-raw`.  
-The `outputType` argument determines if the returned value should be a base64-encoded string or an ArrayBuffer.  
+The `outputType` argument determines if the returned value should be a base64-encoded string or an ArrayBuffer (Uint8Array).  
   
 <details><summary>Example - click to view</summary>
 
@@ -473,13 +472,13 @@ console.log(str === decompressed); // true
 ### `function decompress()`
 Signature:
 ```ts
-function decompress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<ArrayBuffer | string>;
+function decompress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<Uint8Array | string>;
 ```
   
-Decompresses the previously compressed string or ArrayBuffer using the given algorithm and encoding.  
-The `input` argument can be a [`Stringifiable`](#type-stringifiable) object or an ArrayBuffer.  
+Decompresses the previously compressed string or ArrayBuffer (Uint8Array) using the given algorithm and encoding.  
+The `input` argument can be a [`Stringifiable`](#type-stringifiable) object or an ArrayBuffer (Uint8Array).  
 The `compressionFormat` argument can usually be either `gzip`, `deflate` or `deflate-raw`.  
-The `outputType` argument determines if the returned value should be a base64-encoded string or an ArrayBuffer.  
+The `outputType` argument determines if the returned value should be a base64-encoded string or an ArrayBuffer (Uint8Array).  
   
 <details><summary>Example - click to view</summary>
 
@@ -500,14 +499,10 @@ console.log(str === decompressed); // true
 ### `function computeHash()`
 Signature:
 ```ts
-function computeHash(input: string | ArrayBuffer, algorithm = "SHA-256"): Promise<string>;
+function computeHash(input: string | Uint8Array, algorithm = "SHA-256"): Promise<string>;
 ```
-<!-- Creates a hash / checksum of the given {@linkcode input} string or ArrayBuffer using the specified {@linkcode algorithm} ("SHA-256" by default).  
- *   
- * - ⚠️ Uses the SubtleCrypto API so it needs to run in a secure context (HTTPS).  
- * - ⚠️ If you use this for cryptography, make sure to use a secure algorithm (under no circumstances use SHA-1) and to [salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) your input data. -->
   
-Creates a hash / checksum of the given string or ArrayBuffer using the specified algorithm ("SHA-256" by default).  
+Creates a hash / checksum of the given string or ArrayBuffer (Uint8Array) using the specified algorithm ("SHA-256" by default).  
   
 - ⚠️ Uses the SubtleCrypto API so in a DOM environment this needs to run in a secure context (HTTPS).
 - ⚠️ If you use this for cryptography, make sure to use a secure algorithm (under no circumstances use SHA-1) and to [salt your input.](https://en.wikipedia.org/wiki/Salt_(cryptography))

--- a/docs.md
+++ b/docs.md
@@ -772,7 +772,7 @@ Signature:
 deleteData(): Promise<void>;
 ```
   
-Fully deletes the data from persistent storage only.  
+Fully deletes the data from persistent storage only. Also deletes the data container itself, if the storage engine implements the [`deleteStorage()`](#datastoreenginedeletestorage) method.  
 The internal cache will be left untouched, so any subsequent calls to `getData()` will return the data that was last loaded.  
 If `loadData()` or `setData()` are called after this, the persistent storage will be populated with the value of `options.defaultData` again.  
 This is why you should either immediately repopulate the cache and persistent storage or the page should probably be reloaded or closed after this method is called.
@@ -1268,6 +1268,16 @@ abstract deleteValue(name: string): Promise<void>;
   
 Must be implemented by the engine subclass.  
 Is called to delete the value of the given name from persistent storage.  
+
+<br>
+
+### `DataStoreEngine.deleteStorage()`
+Signature:
+```ts
+deleteStorage?(): Promise<void>;
+```
+Optional method that may be implemented by the engine subclass. Gets called when the [`DataStore.deleteData()`](#datastoredeletedata) method is called.  
+If called, it should delete all data stored by the engine by deleting the storage container itself (e.g. the file or database).
 
 <br>
 

--- a/docs.md
+++ b/docs.md
@@ -2183,7 +2183,7 @@ overflowVal(value: number, min: number, max: number): number
 overflowVal(value: number, max: number): number
 ```
   
-Returns the value of a number that over- and underflows to conform to the given range.  
+Returns the value of a number that over- and underflows to conform to the given (inclusive) range.  
 This differs from the [`clamp()` function](#function-clamp) in that it will wrap the value around at the edges of the range instead of just pinning it to a given boundary.  
   
 If only the `max` argument is passed, the `min` will be set to 0.  

--- a/docs.md
+++ b/docs.md
@@ -83,6 +83,7 @@ For submitting bug reports or feature requests, please use the [GitHub issue tra
     - 🟣 [`function formatNumber()`](#function-formatnumber) - Formats a number to a string using the given locale and format identifier
       - 🔷 [`type NumberFormat`](#type-numberformat) - Number format identifier
     - 🟣 [`function mapRange()`](#function-maprange) - Maps a number from one range to another
+    - 🟣 [`function overflowVal()`](#function-overflowVal) - Makes sure a number is in a range by over- & underflowing it
     - 🟣 [`function randRange()`](#function-randrange) - Returns a random number in the given range
     - 🟣 [`function roundFixed()`](#function-roundfixed) - Rounds the given number to the given number of decimal places
     - 🟣 [`function valsWithin()`](#function-valswithin) - Checks if the given numbers are within a certain range of each other
@@ -2168,6 +2169,43 @@ mapRange(5, 10, 50);        // 25
 // to calculate a percentage from arbitrary values, use 0 and 100 as the second range
 // for example, if 4 files of a total of 13 were downloaded:
 mapRange(4, 0, 13, 0, 100); // 30.76923076923077
+```
+</details>
+
+<br>
+
+### `function overflowVal()`
+Signatures:
+```ts
+// with min:
+overflowVal(value: number, min: number, max: number): number
+// without min (defaults to 0):
+overflowVal(value: number, max: number): number
+```
+  
+Returns the value of a number that over- and underflows to conform to the given range.  
+This differs from the [`clamp()` function](#function-clamp) in that it will wrap the value around at the edges of the range instead of just pinning it to a given boundary.  
+  
+If only the `max` argument is passed, the `min` will be set to 0.  
+  
+If the given value is already within the range, it will be returned unchanged.  
+If any argument is `NaN`, `Infinity` or `-Infinity`, it will return `NaN`, since those are not real numbers in a mathematical sense.  
+  
+<details><summary><b>Example - click to view</b></summary>
+
+```ts
+import { overflowVal } from "@sv443-network/coreutils";
+
+overflowVal(5, 0, 10);     // 5
+overflowVal(15, 0, 10);    // 4
+overflowVal(-5, 0, 10);    // 6
+overflowVal(3, 2);         // 0
+
+overflowVal(NaN, 10);      // NaN
+overflowVal(Infinity, 10); // NaN
+overflowVal(3, Infinity);  // NaN
+
+overflowVal(1, 10, 0);     // throws RangeError
 ```
 </details>
 

--- a/docs.md
+++ b/docs.md
@@ -136,6 +136,12 @@ For submitting bug reports or feature requests, please use the [GitHub issue tra
     - 🔷 [`type ValueGen`](#type-valuegen) - A value that can be either the generic type T, or a sync or async function that returns T
     - 🔷 [`type Stringifiable`](#type-stringifiable) - Any value that can be implicitly converted to a string
 
+> [!NOTE]  
+> 🟣 = function  
+> 🟧 = class  
+> 🔷 = type  
+> 🟩 = const
+
 <br><br><br>
 
 

--- a/docs.md
+++ b/docs.md
@@ -108,7 +108,7 @@ For submitting bug reports or feature requests, please use the [GitHub issue tra
       - 🟩 [`const defaultPbChars`](#const-defaultpbchars) - Default characters for the progress bar
       - 🔷 [`type ProgressBarChars`](#type-progressbarchars) - Type for the progress bar characters object
     - 🟣 [`function joinArrayReadable()`](#function-joinarrayreadable) - Joins the given array into a string, using the given separators and last separator
-    - 🟣 [`function secsToTimeStr()`](#function-sectostimestr) - Turns the given number of seconds into a string in the format `(hh:)mm:ss` with intelligent zero-padding
+    - 🟣 [`function secsToTimeStr()`](#function-secstotimestr) - Turns the given number of seconds into a string in the format `(hh:)mm:ss` with intelligent zero-padding
     - 🟣 [`function truncStr()`](#function-truncstr) - Truncates the given string to the given length
   <!-- - *[**TieredCache:**](#tieredcache)
     - 🟧 *[`class TieredCache`](#class-tieredcache) - A multi-tier cache that uses multiple storage engines with different expiration times

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,11 +26,26 @@ const config = [
       "**/test.ts",
       "test/**/*",
       "**/*.spec.ts",
+      "**/*.mjs",
+      "**/*.cjs",
+      "**/*.js",
+      "tools/**/*",
+      "vitest.config.ts",
     ],
-  }, ...compat.extends(
+  },
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  ...compat.extends(
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-  ), {
+  ),
+  {
     plugins: {
       "@typescript-eslint": typescriptEslint,
     },
@@ -78,6 +93,9 @@ const config = [
       "@typescript-eslint/explicit-function-return-type": ["error", {
         allowExpressions: true,
         allowIIFEs: true,
+      }],
+      "@typescript-eslint/unbound-method": ["error", {
+        ignoreStatic: true,
       }],
       "comma-dangle": ["error", "only-multiline"],
       "no-misleading-character-class": "off",

--- a/lib/DataStore.ts
+++ b/lib/DataStore.ts
@@ -128,18 +128,19 @@ export class DataStore<TData extends DataStoreData> {
   public readonly decodeData: DataStoreOptions<TData>["decodeData"];
   public readonly compressionFormat: Exclude<DataStoreOptions<TData>["compressionFormat"], undefined> = "deflate-raw";
   public readonly engine: DataStoreEngine<TData>;
+  public options: DataStoreOptions<TData>;
+
   /**
    * Whether all first-init checks should be done.  
    * This includes migrating the internal DataStore format, migrating data from the UserUtils format, and anything similar.  
    * This is set to `true` by default. Create a subclass and set it to `false` before calling {@linkcode loadData()} if you want to explicitly skip these checks.
    */
   protected firstInit = true;
+
   /** In-memory cached copy of the data that is saved in persistent storage used for synchronous read access. */
   private cachedData: TData;
   private migrations?: DataMigrationsDict;
   private migrateIds: string[] = [];
-
-  public options: DataStoreOptions<TData>;
 
   /**
    * Creates an instance of DataStore to manage a sync & async database that is cached in memory and persistently saved across sessions.  

--- a/lib/DataStore.ts
+++ b/lib/DataStore.ts
@@ -331,7 +331,7 @@ export class DataStore<TData extends DataStoreData> {
 
   /** Returns whether encoding and decoding are enabled for this DataStore instance */
   public encodingEnabled(): this is Required<Pick<DataStoreOptions<TData>, "encodeData" | "decodeData">> {
-    return Boolean(this.encodeData && this.decodeData) || Boolean(this.compressionFormat);
+    return Boolean(this.encodeData && this.decodeData) && this.compressionFormat !== null || Boolean(this.compressionFormat);
   }
 
   //#region migrations

--- a/lib/DataStore.ts
+++ b/lib/DataStore.ts
@@ -296,7 +296,7 @@ export class DataStore<TData extends DataStoreData> {
   }
 
   /**
-   * Call this method to clear all persistently stored data associated with this DataStore instance.  
+   * Call this method to clear all persistently stored data associated with this DataStore instance, including the storage container (if supported by the DataStoreEngine).  
    * The in-memory cache will be left untouched, so you may still access the data with {@linkcode getData()}  
    * Calling {@linkcode loadData()} or {@linkcode setData()} after this method was called will recreate persistent storage with the cached or default data.  
    *   
@@ -307,6 +307,7 @@ export class DataStore<TData extends DataStoreData> {
       this.engine.deleteValue(`__ds-${this.id}-dat`),
       this.engine.deleteValue(`__ds-${this.id}-ver`),
       this.engine.deleteValue(`__ds-${this.id}-enc`),
+      this.engine.deleteStorage?.(),
     ]);
   }
 

--- a/lib/DataStoreEngine.spec.ts
+++ b/lib/DataStoreEngine.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { access, readFile } from "node:fs/promises";
+import { FileStorageEngine } from "./DataStoreEngine";
+import { DatedError } from "./Errors";
+
+describe("FileStorageEngine", () => {
+  //#region storage API
+
+  it("Storage API works as expected", async () => {
+    const engine = new FileStorageEngine({
+      filePath: "./test-data",
+      dataStoreOptions: {
+        id: "test",
+      },
+    });
+
+    await engine.setValue("key", "val");
+
+    expect(await engine.getValue("key", "default")).toBe("val");
+    expect(await engine.getValue("nonexistent", "default")).toBe("default");
+
+    const foo = { bar: 1 };
+    expect(engine.deepCopy(foo)).toEqual(foo);
+    expect(engine.deepCopy(foo) === foo).toBe(false);
+
+    await engine.deleteStorage();
+
+    try {
+      await access("./test-data");
+      throw new Error("File should not exist");
+    }
+    catch(e) {
+      expect((e as NodeJS.ErrnoException)?.code).toBe("ENOENT");
+    }
+  });
+
+  //#region errors
+
+  it("Throws when no DataStoreOptions are provided", async () => {
+    try {
+      const engine = new FileStorageEngine({ filePath: "./test-data" });
+      await engine.setValue("key", "val");
+
+      throw new Error("Should have thrown an error");
+    }
+    catch(e) {
+      expect(e).toBeInstanceOf(DatedError);
+    }
+
+    try {
+      // @ts-expect-error
+      const engine = new FileStorageEngine({ filePath: "./test-data", dataStoreOptions: {} });
+      await engine.setValue("key", "val");
+
+      throw new Error("Should have thrown an error");
+    }
+    catch(e) {
+      expect(e).toBeInstanceOf(DatedError);
+    }
+  });
+
+  //#region w/o structuredClone
+
+  it("Use JSON reserialize when structuredClone is not available", async () => {
+    const originalStructuredClone = globalThis.structuredClone;
+    // @ts-expect-error
+    globalThis.structuredClone = undefined;
+
+    const engine = new FileStorageEngine({
+      filePath: "./test-data",
+      dataStoreOptions: {
+        id: "test",
+      },
+    });
+
+    const foo = { bar: 1 };
+    expect(engine.deepCopy(foo)).toEqual(foo);
+    expect(engine.deepCopy(foo) === foo).toBe(false);
+
+    globalThis.structuredClone = originalStructuredClone;
+  });
+});

--- a/lib/DataStoreEngine.ts
+++ b/lib/DataStoreEngine.ts
@@ -22,7 +22,7 @@ export interface DataStoreEngine<TData extends DataStoreData> { // eslint-disabl
 export abstract class DataStoreEngine<TData extends DataStoreData> {
   protected dataStoreOptions!: DataStoreOptions<TData>; // setDataStoreOptions() is called from inside the DataStore constructor to set this value
 
-  /** Called by DataStore on creation, to pass its options */
+  /** Called by DataStore on creation, to pass its options. Only overwrite the options if you are absolutely sure you know what you're doing! */
   public setDataStoreOptions(dataStoreOptions: DataStoreOptions<TData>): void {
     this.dataStoreOptions = dataStoreOptions;
   }

--- a/lib/DataStoreEngine.ts
+++ b/lib/DataStoreEngine.ts
@@ -10,6 +10,7 @@ import type { Prettify, SerializableVal } from "./types.js";
 
 //#region >> DataStoreEngine
 
+/** Contains the only properties of {@linkcode DataStoreOptions} that are relevant to the {@linkcode DataStoreEngine} class. */
 export type DataStoreEngineDSOptions<TData extends DataStoreData> = Prettify<Pick<DataStoreOptions<TData>, "decodeData" | "encodeData" | "id">>;
 
 export interface DataStoreEngine<TData extends DataStoreData> { // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -47,7 +48,7 @@ export abstract class DataStoreEngine<TData extends DataStoreData> {
 
   /** Serializes the given object to a string, optionally encoded with `options.encodeData` if {@linkcode useEncoding} is set to true */
   public async serializeData(data: TData, useEncoding?: boolean): Promise<string> {
-    this.validateDataStoreOptions();
+    this.ensureDataStoreOptions();
 
     const stringData = JSON.stringify(data);
     if(!useEncoding || !this.dataStoreOptions?.encodeData || !this.dataStoreOptions?.decodeData)
@@ -61,7 +62,7 @@ export abstract class DataStoreEngine<TData extends DataStoreData> {
 
   /** Deserializes the given string to a JSON object, optionally decoded with `options.decodeData` if {@linkcode useEncoding} is set to true */
   public async deserializeData(data: string, useEncoding?: boolean): Promise<TData> {
-    this.validateDataStoreOptions();
+    this.ensureDataStoreOptions();
 
     let decRes = this.dataStoreOptions?.decodeData && useEncoding ? this.dataStoreOptions.decodeData?.[1]?.(data) : undefined;
     if(decRes instanceof Promise)
@@ -73,7 +74,7 @@ export abstract class DataStoreEngine<TData extends DataStoreData> {
   //#region misc api
 
   /** Throws an error if the DataStoreOptions are not set or invalid */
-  protected validateDataStoreOptions(): void {
+  protected ensureDataStoreOptions(): void {
     if(!this.dataStoreOptions)
       throw new DatedError("DataStoreEngine must be initialized with DataStore options before use. If you are using this instance standalone, set them in the constructor or call `setDataStoreOptions()` with the DataStore options.");
     if(!this.dataStoreOptions.id)
@@ -104,7 +105,7 @@ export type BrowserStorageEngineOptions = {
   type?: "localStorage" | "sessionStorage";
   /**
    * Specifies the necessary options for storing data.  
-   * - ⚠️ Only call this if you are using this instance standalone! The parent DataStore will set this automatically.
+   * - ⚠️ Only specify this if you are using this instance standalone! The parent DataStore will set this automatically.
    */
   dataStoreOptions?: DataStoreEngineDSOptions<DataStoreData>;
 };
@@ -173,7 +174,7 @@ export type FileStorageEngineOptions = {
   filePath?: ((dataStoreID: string) => string) | string;
   /**
    * Specifies the necessary options for storing data.  
-   * - ⚠️ Only call this if you are using this instance standalone! The parent DataStore will set this automatically.
+   * - ⚠️ Only specify this if you are using this instance standalone! The parent DataStore will set this automatically.
    */
   dataStoreOptions?: DataStoreEngineDSOptions<DataStoreData>;
 };
@@ -205,7 +206,7 @@ export class FileStorageEngine<TData extends DataStoreData> extends DataStoreEng
 
   /** Reads the file contents */
   protected async readFile(): Promise<TData | undefined> {
-    this.validateDataStoreOptions();
+    this.ensureDataStoreOptions();
 
     try {
       if(!fs)
@@ -229,7 +230,7 @@ export class FileStorageEngine<TData extends DataStoreData> extends DataStoreEng
 
   /** Overwrites the file contents */
   protected async writeFile(data: TData): Promise<void> {
-    this.validateDataStoreOptions();
+    this.ensureDataStoreOptions();
 
     try {
       if(!fs)
@@ -284,7 +285,7 @@ export class FileStorageEngine<TData extends DataStoreData> extends DataStoreEng
 
   /** Deletes the file that contains the data of this DataStore. */
   public async deleteStorage(): Promise<void> {
-    this.validateDataStoreOptions();
+    this.ensureDataStoreOptions();
 
     try {
       if(!fs)

--- a/lib/DataStoreEngine.ts
+++ b/lib/DataStoreEngine.ts
@@ -104,7 +104,7 @@ export type BrowserStorageEngineOptions = {
   type?: "localStorage" | "sessionStorage";
   /**
    * Specifies the necessary options for storing data.  
-   * ⚠️ Only call this if you are using this instance standalone! The parent DataStore will set this automatically.
+   * - ⚠️ Only call this if you are using this instance standalone! The parent DataStore will set this automatically.
    */
   dataStoreOptions?: DataStoreEngineDSOptions<DataStoreData>;
 };
@@ -112,8 +112,8 @@ export type BrowserStorageEngineOptions = {
 /**
  * Storage engine for the {@linkcode DataStore} class that uses the browser's LocalStorage or SessionStorage to store data.  
  *   
- * ⚠️ Requires a DOM environment
- * ⚠️ Don't reuse this engine across multiple {@linkcode DataStore} instances
+ * - ⚠️ Requires a DOM environment
+ * - ⚠️ Don't reuse engines across multiple {@linkcode DataStore} instances
  */
 export class BrowserStorageEngine<TData extends DataStoreData> extends DataStoreEngine<TData> {
   protected options: BrowserStorageEngineOptions & Required<Pick<BrowserStorageEngineOptions, "type">>;
@@ -121,8 +121,8 @@ export class BrowserStorageEngine<TData extends DataStoreData> extends DataStore
   /**
    * Creates an instance of `BrowserStorageEngine`.  
    *   
-   * ⚠️ Requires a DOM environment  
-   * ⚠️ Don't reuse this engine across multiple {@linkcode DataStore} instances
+   * - ⚠️ Requires a DOM environment  
+   * - ⚠️ Don't reuse engines across multiple {@linkcode DataStore} instances
    */
   constructor(options?: BrowserStorageEngineOptions) {
     super(options?.dataStoreOptions);
@@ -173,7 +173,7 @@ export type FileStorageEngineOptions = {
   filePath?: ((dataStoreID: string) => string) | string;
   /**
    * Specifies the necessary options for storing data.  
-   * ⚠️ Only call this if you are using this instance standalone! The parent DataStore will set this automatically.
+   * - ⚠️ Only call this if you are using this instance standalone! The parent DataStore will set this automatically.
    */
   dataStoreOptions?: DataStoreEngineDSOptions<DataStoreData>;
 };
@@ -181,8 +181,8 @@ export type FileStorageEngineOptions = {
 /**
  * Storage engine for the {@linkcode DataStore} class that uses a JSON file to store data.  
  *   
- * ⚠️ Requires Node.js or Deno with Node compatibility (v1.31+)  
- * ⚠️ Don't reuse this engine across multiple {@linkcode DataStore} instances
+ * - ⚠️ Requires Node.js or Deno with Node compatibility (v1.31+)  
+ * - ⚠️ Don't reuse engines across multiple {@linkcode DataStore} instances
  */
 export class FileStorageEngine<TData extends DataStoreData> extends DataStoreEngine<TData> {
   protected options: FileStorageEngineOptions & Required<Pick<FileStorageEngineOptions, "filePath">>;
@@ -190,8 +190,8 @@ export class FileStorageEngine<TData extends DataStoreData> extends DataStoreEng
   /**
    * Creates an instance of `FileStorageEngine`.  
    *   
-   * ⚠️ Requires Node.js or Deno with Node compatibility (v1.31+)  
-   * ⚠️ Don't reuse this engine across multiple {@linkcode DataStore} instances
+   * - ⚠️ Requires Node.js or Deno with Node compatibility (v1.31+)  
+   * - ⚠️ Don't reuse engines across multiple {@linkcode DataStore} instances
    */
   constructor(options?: FileStorageEngineOptions) {
     super(options?.dataStoreOptions);

--- a/lib/DataStoreSerializer.spec.ts
+++ b/lib/DataStoreSerializer.spec.ts
@@ -22,7 +22,7 @@ const store2 = new DataStore({
   defaultData: { c: 1, d: 2 },
   formatVersion: 1,
   engine: () => new FileStorageEngine({
-    filePath: "./test.json",
+    filePath: () => "./test.json",
   }),
   encodeData: [compFmt, async (data) => await compress(data, compFmt, "string")],
   decodeData: [compFmt, async (data) => await decompress(data, compFmt, "string")],

--- a/lib/DataStoreSerializer.spec.ts
+++ b/lib/DataStoreSerializer.spec.ts
@@ -6,31 +6,26 @@ import { beforeEach } from "node:test";
 import { compress, decompress } from "./crypto.js";
 import { FileStorageEngine } from "./DataStoreEngine.js";
 
-const store1 = new DataStore({
-  id: "dss-test-1",
-  defaultData: { a: 1, b: 2 },
-  formatVersion: 1,
-  engine: () => new FileStorageEngine({
-    filePath: "./test.json",
-  }),
-  compressionFormat: null,
-});
-
-const compFmt = "deflate-raw";
-const store2 = new DataStore({
-  id: "dss-test-2",
-  defaultData: { c: 1, d: 2 },
-  formatVersion: 1,
-  engine: () => new FileStorageEngine({
-    filePath: () => "./test.json",
-  }),
-  encodeData: [compFmt, async (data) => await compress(data, compFmt, "string")],
-  decodeData: [compFmt, async (data) => await decompress(data, compFmt, "string")],
-});
-
 const getStores = () => [
-  store1,
-  store2,
+  new DataStore({
+    id: "dss-test-1",
+    defaultData: { a: 1, b: 2 },
+    formatVersion: 1,
+    engine: () => new FileStorageEngine({
+      filePath: "./test.json",
+    }),
+    compressionFormat: null,
+  }),
+  new DataStore({
+    id: "dss-test-2",
+    defaultData: { c: 1, d: 2 },
+    formatVersion: 1,
+    engine: () => new FileStorageEngine({
+      filePath: () => "./test.json",
+    }),
+    encodeData: ["deflate-raw", async (data) => await compress(data, "deflate-raw", "string")],
+    decodeData: ["deflate-raw", async (data) => await decompress(data, "deflate-raw", "string")],
+  }),
 ];
 
 describe("DataStoreSerializer", () => {
@@ -75,6 +70,7 @@ describe("DataStoreSerializer", () => {
 
   it("Deserialization", async () => {
     const stores = getStores();
+    const [store1, store2] = stores;
     const ser = new DataStoreSerializer(stores);
 
     await ser.deserialize(`[{"id":"dss-test-2","data":"{\\"c\\":420,\\"d\\":420}","formatVersion":1,"encoded":false}]`);

--- a/lib/DataStoreSerializer.spec.ts
+++ b/lib/DataStoreSerializer.spec.ts
@@ -6,6 +6,8 @@ import { beforeEach } from "node:test";
 import { compress, decompress } from "./crypto.js";
 import { FileStorageEngine } from "./DataStoreEngine.js";
 
+//#region consts
+
 const getStores = () => [
   new DataStore({
     id: "dss-test-1",
@@ -29,6 +31,8 @@ const getStores = () => [
 ];
 
 describe("DataStoreSerializer", () => {
+  //#region hooks
+
   beforeEach(async () => {
     const ser = new DataStoreSerializer(getStores());
     await ser.deleteStoresData();
@@ -40,6 +44,8 @@ describe("DataStoreSerializer", () => {
     await new DataStoreSerializer(getStores()).deleteStoresData();
     await unlink("./test.json").catch(() => {});
   });
+
+  //#region serialization
 
   it("Serialization", async () => {
     const ser = new DataStoreSerializer(getStores());
@@ -67,6 +73,8 @@ describe("DataStoreSerializer", () => {
       },
     ]);
   });
+
+  //#region deserialization
 
   it("Deserialization", async () => {
     const stores = getStores();

--- a/lib/DataStoreSerializer.ts
+++ b/lib/DataStoreSerializer.ts
@@ -100,15 +100,16 @@ export class DataStoreSerializer<TData extends DataStoreData> {
     const serData: SerializedDataStore[] = [];
 
     for(const storeInst of this.stores.filter(s => typeof stores === "function" ? stores(s.id) : stores.includes(s.id))) {
-      const data = useEncoding && storeInst.encodingEnabled()
-        ? await storeInst.encodeData[1](JSON.stringify(storeInst.getData()))
+      const encoded = Boolean(useEncoding && storeInst.encodingEnabled() && storeInst.encodeData?.[1]);
+      const data = encoded
+        ? await storeInst.encodeData![1](JSON.stringify(storeInst.getData()))
         : JSON.stringify(storeInst.getData());
 
       serData.push({
         id: storeInst.id,
         data,
         formatVersion: storeInst.formatVersion,
-        encoded: useEncoding && storeInst.encodingEnabled(),
+        encoded,
         checksum: this.options.addChecksum
           ? await this.calcChecksum(data)
           : undefined,

--- a/lib/Errors.spec.ts
+++ b/lib/Errors.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ChecksumMismatchError, DatedError, MigrationError, ValidationError } from "./Errors.js";
+import { valsWithin } from "./math.js";
 
 describe("Errors", () => {
   it("All class instances have the date property", () => {
@@ -9,13 +10,15 @@ describe("Errors", () => {
       ["MigrationError", MigrationError],
       ["ValidationError", ValidationError],
     ] as const;
+    const errTime = Date.now();
 
     for(const [name, Cls] of classes) {
       const instance = new Cls(`Test ${name}`);
       expect(instance).toBeInstanceOf(Cls);
-      expect(instance.date).toBeInstanceOf(Date);
-      expect(instance.message).toBe(`Test ${name}`);
       expect(instance.name).toBe(name);
+      expect(instance.message).toBe(`Test ${name}`);
+      expect(instance.date).toBeInstanceOf(Date);
+      expect(valsWithin(errTime, instance.date.getTime(), undefined, 100)).toBe(true);
     }
   });
 });

--- a/lib/NanoEmitter.spec.ts
+++ b/lib/NanoEmitter.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { NanoEmitter } from "./NanoEmitter.js";
 
 describe("NanoEmitter", () => {
+  //#region FP
+
   it("Functional", async () => {
     const evts = new NanoEmitter<{
       val: (v1: number, v2: number) => void;
@@ -35,6 +37,8 @@ describe("NanoEmitter", () => {
     evts.emit("val", 40, 40);
     expect(v3 + v4).toBe(60);
   });
+
+  //#region OOP
 
   it("Object oriented", async () => {
     class MyEmitter extends NanoEmitter<{

--- a/lib/NanoEmitter.spec.ts
+++ b/lib/NanoEmitter.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { NanoEmitter } from "./NanoEmitter.js";
 
-describe("NanoEmitter", () => {
-  //#region FP
+describe("NanoEmitter base functionality", () => {
+  //#region base - FP
 
   it("Functional", async () => {
     const evts = new NanoEmitter<{
@@ -61,4 +61,184 @@ describe("NanoEmitter", () => {
 
     expect(evts.emit("val", 0, 0)).toBe(false);
   });
+});
+
+describe("NanoEmitter onMulti", () => {
+  //#region onMulti allOf
+  it("allOf", () => {
+    const evts = new NanoEmitter<{
+      val1: (val: number) => void;
+      val2: (val: number) => void;
+    }>({
+      publicEmit: true,
+    });
+
+    let cbVal = -1;
+
+    evts.onMulti([
+      {
+        allOf: ["val1", "val2"],
+        callback: (event, val) => {
+          cbVal = val;
+        },
+      },
+    ]);
+
+    evts.emit("val1", 1);
+    expect(cbVal).toBe(-1);
+
+    evts.emit("val2", 2);
+    expect(cbVal).toBe(2);
+
+    evts.emit("val1", 3);
+    expect(cbVal).toBe(3);
+  });
+
+  //#region onMulti oneOf
+  it("oneOf", () => {
+    const evts = new NanoEmitter<{
+      val1: (val: number) => void;
+      val2: (val: number) => void;
+    }>({
+      publicEmit: true,
+    });
+
+    let cbVal = -1;
+
+    const unsub = evts.onMulti([
+      {
+        oneOf: ["val1", "val2"],
+        callback: (event, val) => {
+          cbVal = val;
+        },
+      },
+    ]);
+
+    evts.emit("val1", 1);
+    expect(cbVal).toBe(1);
+
+    evts.emit("val2", 2);
+    expect(cbVal).toBe(2);
+
+    unsub();
+
+    evts.emit("val1", 3);
+    expect(cbVal).toBe(2);
+  });
+
+  // #region onMulti oneOf once
+  it("oneOf once", () => {
+    const evts = new NanoEmitter<{
+      val1: (val: number) => void;
+      val2: (val: number) => void;
+    }>({
+      publicEmit: true,
+    });
+
+    let cbVal = -1;
+
+    evts.onMulti({
+      oneOf: ["val1", "val2"],
+      once: true,
+      callback: (event, val) => {
+        cbVal = val;
+      },
+    });
+
+    evts.emit("val1", 1);
+    expect(cbVal).toBe(1);
+
+    evts.emit("val2", 2);
+    expect(cbVal).toBe(1);
+  });
+
+  // #region onMulti allOf once
+  it("allOf once", () => {
+    const evts = new NanoEmitter<{
+      val1: (val: number) => void;
+      val2: (val: number) => void;
+    }>({
+      publicEmit: true,
+    });
+
+    let cbVal = -1;
+
+    evts.onMulti({
+      allOf: ["val1", "val2"],
+      once: true,
+      callback: (event, val) => {
+        cbVal = val;
+      },
+    });
+
+    evts.emit("val1", 1);
+    expect(cbVal).toBe(-1);
+
+    evts.emit("val2", 2);
+    expect(cbVal).toBe(2);
+
+    evts.emit("val1", 3);
+    expect(cbVal).toBe(2);
+  });
+
+  // #region onMulti oneOf + allOf
+  it("allOf + oneOf", () => {
+    const evts = new NanoEmitter<{
+      val1: (val: number) => void;
+      val2: (val: number) => void;
+      val3: (val: number) => void;
+    }>({
+      publicEmit: true,
+    });
+
+    let cbVal = -1;
+
+    evts.onMulti({
+      oneOf: ["val1", "val2"],
+      allOf: ["val2", "val3"],
+      callback: (event, val) => {
+        cbVal = val;
+      },
+    });
+
+    evts.emit("val1", 1);
+    expect(cbVal).toBe(1);
+
+    evts.emit("val3", 3);
+    expect(cbVal).toBe(1);
+
+    evts.emit("val2", 2);
+    expect(cbVal).toBe(2);
+
+    evts.emit("val1", 1);
+    expect(cbVal).toBe(1);
+  });
+
+  //#region onMulti edge cases
+  it("Handles edge cases", () => {
+    const evts = new NanoEmitter();
+    expect(() => {
+      // @ts-expect-error
+      evts.onMulti({
+        once: true,
+        callback: () => void 0,
+      });
+    }).toThrow(TypeError);
+
+    const ac = new AbortController();
+    ac.abort();
+
+    let cbVal = -1;
+
+    evts.onMulti({
+      signal: ac.signal,
+      oneOf: ["val1", "val2"],
+      callback: (event, val) => {
+        cbVal = val;
+      },
+    });
+
+    evts.emit("val1", 1);
+    expect(cbVal).toBe(-1);
+  })
 });

--- a/lib/NanoEmitter.ts
+++ b/lib/NanoEmitter.ts
@@ -101,7 +101,7 @@ export class NanoEmitter<TEvtMap extends EventsMap = DefaultEvents> {
 
   /**
    * Emits an event on this instance.  
-   * ⚠️ Needs `publicEmit` to be set to true in the NanoEmitter constructor or super() call!
+   * - ⚠️ Needs `publicEmit` to be set to true in the NanoEmitter constructor or super() call!
    * @param event The event to emit
    * @param args The arguments to pass to the event listeners
    * @returns Returns true if `publicEmit` is true and the event was emitted successfully

--- a/lib/NanoEmitter.ts
+++ b/lib/NanoEmitter.ts
@@ -4,11 +4,40 @@
  */
 
 import { createNanoEvents, type DefaultEvents, type Emitter, type EventsMap, type Unsubscribe } from "nanoevents";
+import type { Prettify } from "./types.js";
+
+//#region types
 
 export interface NanoEmitterOptions {
   /** If set to true, allows emitting events through the public method emit() */
   publicEmit: boolean;
 }
+
+type NanoEmitterOnMultiTriggerOptions<TEvtMap extends EventsMap, TKey extends keyof TEvtMap = keyof TEvtMap> = {
+  /** Calls the callback when one of the given events is emitted */
+  oneOf?: TKey[];
+  /** Calls the callback when all of the given events are emitted */
+  allOf?: TKey[];
+}
+
+/** Options for the {@linkcode NanoEmitter.onMulti()} method */
+export type NanoEmitterOnMultiOptions<TEvtMap extends EventsMap, TKey extends keyof TEvtMap = keyof TEvtMap> = Prettify<
+  & {
+    /** If true, the callback will be called only once for the first event (or set of events) that match the criteria */
+    once?: boolean;
+    /** If provided, can be used to abort the subscription if the signal is aborted */
+    signal?: AbortSignal;
+    /** The callback to call when the event with the given name is emitted */
+    callback: (event: TKey, ...args: Parameters<TEvtMap[TKey]>) => void;
+  }
+  & NanoEmitterOnMultiTriggerOptions<TEvtMap, TKey>
+  & (
+    | Pick<Required<NanoEmitterOnMultiTriggerOptions<TEvtMap, TKey>>, "oneOf">
+    | Pick<Required<NanoEmitterOnMultiTriggerOptions<TEvtMap, TKey>>, "allOf">
+  )
+>;
+
+//#region NanoEmitter
 
 /**
  * Class that can be extended or instantiated by itself to create a lightweight event emitter with helper methods and a strongly typed event map.  
@@ -26,6 +55,8 @@ export class NanoEmitter<TEvtMap extends EventsMap = DefaultEvents> {
       ...options,
     };
   }
+
+  //#region on
 
   /**
    * Subscribes to an event and calls the callback when it's emitted.  
@@ -65,6 +96,8 @@ export class NanoEmitter<TEvtMap extends EventsMap = DefaultEvents> {
     return unsubProxy;
   }
 
+  //#region once
+
   /**
    * Subscribes to an event and calls the callback or resolves the Promise only once when it's emitted.  
    * @param event The event to subscribe to. Use `as "_"` in case your event names aren't thoroughly typed (like when using a template literal, e.g. \`event-${val}\` as "_")
@@ -99,6 +132,117 @@ export class NanoEmitter<TEvtMap extends EventsMap = DefaultEvents> {
     });
   }
 
+  //#region onMulti
+
+  /**
+   * Allows subscribing to multiple events and calling the callback only when one of, all of, or a subset of the events are emitted, either continuously or only once.  
+   * @param options An object or array of objects with the following properties:  
+   * `callback` (required) is the function that will be called when the conditions are met.  
+   *   
+   * Set `once` to true to call the callback only once for the first event (or set of events) that match the criteria, then stop listening.  
+   * If `signal` is provided, the subscription will be aborted when the given signal is aborted.  
+   *   
+   * If `oneOf` is used, the callback will be called when any of the matching events are emitted.  
+   * If `allOf` is used, the callback will be called after all of the matching events are emitted at least once, then any time any of them are emitted.  
+   * You may use a combination of the above two options, but at least one of them must be provided.  
+   *   
+   * @returns Returns a function that can be called to unsubscribe all listeners created by this call. Alternatively, pass an `AbortSignal` to all options objects to achieve the same effect or for finer control.
+   */
+  public onMulti<TEvt extends keyof TEvtMap>(options: NanoEmitterOnMultiOptions<TEvtMap> | Array<NanoEmitterOnMultiOptions<TEvtMap>>): Unsubscribe {
+    const allUnsubs: Unsubscribe[] = [];
+
+    const unsubAll = (): void => {
+      for(const unsub of allUnsubs)
+        unsub();
+      allUnsubs.splice(0, allUnsubs.length);
+      this.eventUnsubscribes = this.eventUnsubscribes.filter(u => !allUnsubs.includes(u));
+    };
+
+    for(const opts of Array.isArray(options) ? options : [options]) {
+      // options defaults:
+
+      const optsWithDefaults = {
+        allOf: [],
+        oneOf: [],
+        once: false,
+        ...opts,
+      } as Prettify<
+        Required<Pick<NanoEmitterOnMultiOptions<TEvtMap>, "allOf" | "oneOf">>
+        & NanoEmitterOnMultiOptions<TEvtMap>
+      >;
+
+      const {
+        oneOf,
+        allOf,
+        once,
+        signal,
+        callback,
+      } = optsWithDefaults;
+
+      if(signal?.aborted)
+        return unsubAll;
+
+      // unsubs:
+
+      const curEvtUnsubs: Unsubscribe[] = [];
+
+      const checkUnsubAllEvt = (force = false): void => {
+        if(!signal?.aborted && !force)
+          return;
+        for(const unsub of curEvtUnsubs)
+          unsub();
+        curEvtUnsubs.splice(0, curEvtUnsubs.length);
+        this.eventUnsubscribes = this.eventUnsubscribes.filter(u => !curEvtUnsubs.includes(u));
+      };
+
+      // oneOf:
+
+      for(const event of oneOf) {
+        const unsub = this.events.on(event, ((...args: Parameters<TEvtMap[typeof event]>) => {
+          checkUnsubAllEvt();
+          callback(event, ...args);
+          if(once)
+            checkUnsubAllEvt(true);
+        }) as TEvtMap[typeof event]);
+
+        curEvtUnsubs.push(unsub);
+      }
+
+      // allOf:
+
+      const allOfEmitted: Set<TEvt> = new Set();
+
+      const checkAllOf = (event: TEvt, ...args: Parameters<TEvtMap[TEvt]>): void => {
+        checkUnsubAllEvt();
+        allOfEmitted.add(event);
+        if(allOfEmitted.size === allOf.length) {
+          callback(event, ...args);
+          if(once)
+            checkUnsubAllEvt(true);
+        }
+      };
+
+      for(const event of allOf) {
+        const unsub = this.events.on(event, ((...args: Parameters<TEvtMap[typeof event]>) => {
+          checkUnsubAllEvt();
+          checkAllOf(event as TEvt, ...args);
+        }) as TEvtMap[typeof event]);
+
+        curEvtUnsubs.push(unsub);
+      }
+
+      // if no events are provided, throw an error
+      if(oneOf.length === 0 && allOf.length === 0)
+        throw new TypeError("NanoEmitter.onMulti(): Either `oneOf` or `allOf` or both must be provided in the options");
+
+      allUnsubs.push(() => checkUnsubAllEvt(true));
+    }
+
+    return unsubAll;
+  }
+
+  //#region emit
+
   /**
    * Emits an event on this instance.  
    * - ⚠️ Needs `publicEmit` to be set to true in the NanoEmitter constructor or super() call!
@@ -113,6 +257,8 @@ export class NanoEmitter<TEvtMap extends EventsMap = DefaultEvents> {
     }
     return false;
   }
+
+  //#region unsubscribeAll
 
   /** Unsubscribes all event listeners from this instance */
   public unsubscribeAll(): void {

--- a/lib/TieredCache.ts
+++ b/lib/TieredCache.ts
@@ -60,7 +60,7 @@ export type TieredCacheTierOptions<TData extends DataStoreData> = Prettify<{
   /**
    * Engine used for persistent storage. Can be a function that returns a DataStoreEngine or a DataStoreEngine instance.  
    * If this property is not set, this tier will not persist data and only keeps it in memory.  
-   * ⚠️ **Don't reuse instances in multiple tiers and make sure the ID is always unique!**
+   * - ⚠️ **Don't reuse instances in multiple tiers and make sure the ID is always unique!**
    */
   engine?: (() => DataStoreEngine<TData>) | DataStoreEngine<TData>;
   /** Which compression format to use for this tier's persistent storage. Defaults to `deflate-raw` - set to `null` to disable compression. */

--- a/lib/Translate.ts
+++ b/lib/Translate.ts
@@ -170,7 +170,7 @@ export class Translate {
 //  * Returns the translated text for the specified key in the specified language.  
 //  * If the key is not found in the specified previously registered translation, the key itself is returned.  
 //  *   
-//  * ⚠️ Remember to register a language with {@linkcode tr.addTranslations()} before using this function, otherwise it will always return the key itself.
+//  * - ⚠️ Remember to register a language with {@linkcode tr.addTranslations()} before using this function, otherwise it will always return the key itself.
 //  * @param language Language code or name to use for the translation
 //  * @param key Key of the translation to return
 //  * @param args Optional arguments to be passed to the translated text. They will replace placeholders in the format `%n`, where `n` is the 1-indexed argument number

--- a/lib/colors.spec.ts
+++ b/lib/colors.spec.ts
@@ -4,7 +4,7 @@ import { darkenColor, hexToRgb, lightenColor, rgbToHex } from "./colors.js";
 //#region hexToRgb
 describe("colors/hexToRgb", () => {
   it("Converts a hex color string to an RGB tuple", () => {
-    const hex = "#FF0000";
+    const hex = "#F00";
     const [r, g, b, a] = hexToRgb(hex);
 
     expect(r).toBe(255);
@@ -57,6 +57,11 @@ describe("colors/lightenColor", () => {
     expect(lightenColor("ab35de", Infinity, true)).toBe("FFFFFF");
     expect(lightenColor("rgba(255, 50, 127, 0.5)", 50)).toBe("rgba(255, 75, 190.5, 0.5)");
     expect(lightenColor("rgb(255, 50, 127)", 50)).toBe("rgb(255, 75, 190.5)");
+  });
+
+  it("Handles edge cases", () => {
+    expect(() => lightenColor("z", 50)).toThrowError(TypeError);
+    expect(() => lightenColor("rgbz", 50)).toThrowError(TypeError);
   });
 });
 

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -43,10 +43,8 @@ export function darkenColor(color: string, percent: number, upperCase = false): 
     return rgbToHex(r, g, b, a, color.startsWith("#"), upperCase);
   else if(color.startsWith("rgba"))
     return `rgba(${r}, ${g}, ${b}, ${a ?? NaN})`;
-  else if(color.startsWith("rgb"))
-    return `rgb(${r}, ${g}, ${b})`;
   else
-    throw new TypeError("Unsupported color format");
+    return `rgb(${r}, ${g}, ${b})`;
 }
 
 /**

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -53,7 +53,9 @@ export function darkenColor(color: string, percent: number, upperCase = false): 
  */
 export function hexToRgb(hex: string): [red: number, green: number, blue: number, alpha?: number] {
   hex = (hex.startsWith("#") ? hex.slice(1) : hex).trim();
-  const a = hex.length === 8 || hex.length === 4 ? parseInt(hex.slice(-(hex.length / 4)), 16) / (hex.length === 8 ? 255 : 15) : undefined;
+  const a = hex.length === 8 || hex.length === 4
+    ? parseInt(hex.slice(-(hex.length / 4)), 16) / (hex.length === 8 ? 255 : 15)
+    : undefined;
 
   if(!isNaN(Number(a)))
     hex = hex.slice(0, -(hex.length / 4));

--- a/lib/crypto.spec.ts
+++ b/lib/crypto.spec.ts
@@ -20,7 +20,7 @@ describe("crypto/compress", () => {
     const ab = await compress(view, "gzip", "arrayBuffer");
 
     expect(ab).toBeInstanceOf(Uint8Array);
-    expect(abtoa(ab)).toEqual("H4sIAAAAAAAACmNkYmZhBQD0mQtHBQAAAA==");
+    expect(abtoa(ab).startsWith("H4sI")).toBe(true);
   });
 });
 

--- a/lib/crypto.spec.ts
+++ b/lib/crypto.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compress, computeHash, decompress, randomId } from "./crypto.js";
+import { abtoa, atoab, compress, computeHash, decompress, randomId } from "./crypto.js";
 
 //#region compress
 describe("crypto/compress", () => {
@@ -9,7 +9,18 @@ describe("crypto/compress", () => {
     expect((await compress(input, "gzip", "string")).startsWith("H4sI")).toBe(true);
     expect((await compress(input, "deflate", "string")).startsWith("eJzz")).toBe(true);
     expect((await compress(input, "deflate-raw", "string")).startsWith("80jN")).toBe(true);
-    expect(await compress(input, "gzip", "arrayBuffer")).toBeInstanceOf(ArrayBuffer);
+    expect(await compress(input, "gzip", "arrayBuffer")).toBeInstanceOf(Uint8Array);
+  });
+
+  it("Handles Uint8Array input correctly", async () => {
+    const input = new ArrayBuffer(5);
+    const view = new Uint8Array(input);
+    view.set([1, 2, 3, 4, 5]);
+
+    const ab = await compress(view, "gzip", "arrayBuffer");
+
+    expect(ab).toBeInstanceOf(Uint8Array);
+    expect(abtoa(ab)).toEqual("H4sIAAAAAAAACmNkYmZhBQD0mQtHBQAAAA==");
   });
 });
 
@@ -26,6 +37,23 @@ describe("crypto/decompress", () => {
     expect(await decompress(inputDf, "deflate", "string")).toBe(expectedDecomp);
     expect(await decompress(inputDfRaw, "deflate-raw", "string")).toBe(expectedDecomp);
   });
+
+  it("Handles Uint8Array input correctly", async () => {
+    const inputGz = "H4sIAAAAAAAACvNIzcnJ11Eozy/KSVEEAObG5usNAAAA";
+    const inputDf = "eJzzSM3JyddRKM8vyklRBAAgXgSK";
+    const inputDfRaw = "80jNycnXUSjPL8pJUQQA";
+
+    const inputGzUintArr = new Uint8Array(atoab(inputGz));
+    const inputDfUintArr = new Uint8Array(atoab(inputDf));
+    const inputDfRawUintArr = new Uint8Array(atoab(inputDfRaw));
+
+    const expectedDecomp = new TextEncoder().encode("Hello, world!");
+    const expectedDecompUintArr = new Uint8Array(expectedDecomp.buffer);
+
+    expect(await decompress(inputGzUintArr, "gzip", "arrayBuffer")).toEqual(expectedDecompUintArr);
+    expect(await decompress(inputDfUintArr, "deflate", "arrayBuffer")).toEqual(expectedDecompUintArr);
+    expect(await decompress(inputDfRawUintArr, "deflate-raw", "arrayBuffer")).toEqual(expectedDecompUintArr);
+  });
 });
 
 //#region computeHash
@@ -38,6 +66,13 @@ describe("crypto/computeHash", () => {
     expect(await computeHash(input1, "SHA-256")).toBe("315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3");
     expect(await computeHash(input1, "SHA-512")).toBe("c1527cd893c124773d811911970c8fe6e857d6df5dc9226bd8a160614c0cd963a4ddea2b94bb7d36021ef9d865d5cea294a82dd49a0bb269f51f6e7a57f79421");
     expect(await computeHash(input2, "SHA-256")).toBe(await computeHash(input2, "SHA-256"));
+  });
+
+  it("Handles Uint8Array input correctly", async () => {
+    const input = new TextEncoder().encode("Hello, world!");
+    const expectedHash = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3";
+
+    expect(await computeHash(input, "SHA-256")).toBe(expectedHash);
   });
 });
 

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,70 +1,70 @@
 /**
  * @module crypto
- * This module contains various cryptographic functions, like compression and ArrayBuffer encoding - [see the documentation for more info](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#crypto)
+ * This module contains various cryptographic functions, like compression and Uint8Array encoding - [see the documentation for more info](https://github.com/Sv443-Network/CoreUtils/blob/main/docs.md#crypto)
  */
 
 import { mapRange, randRange } from "./math.js";
 import type { Stringifiable } from "./types.js";
 
-/** Converts an ArrayBuffer to a base64-encoded (ASCII) string */
-export function abtoa(buf: ArrayBuffer): string {
+/** Converts an Uint8Array to a base64-encoded (ASCII) string */
+export function abtoa(buf: Uint8Array): string {
   return btoa(
     new Uint8Array(buf)
       .reduce((data, byte) => data + String.fromCharCode(byte), ""),
   );
 }
 
-/** Converts a base64-encoded (ASCII) string to an ArrayBuffer representation of its bytes */
-export function atoab(str: string): ArrayBuffer {
+/** Converts a base64-encoded (ASCII) string to an Uint8Array representation of its bytes */
+export function atoab(str: string): Uint8Array {
   return Uint8Array.from(atob(str), c => c.charCodeAt(0));
 }
 
-/** Compresses a string or an ArrayBuffer using the provided {@linkcode compressionFormat} and returns it as a base64 string */
-export async function compress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType?: "string"): Promise<string>
-/** Compresses a string or an ArrayBuffer using the provided {@linkcode compressionFormat} and returns it as an ArrayBuffer */
-export async function compress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType: "arrayBuffer"): Promise<ArrayBuffer>
-/** Compresses a string or an ArrayBuffer using the provided {@linkcode compressionFormat} and returns it as a base64 string or ArrayBuffer, depending on what {@linkcode outputType} is set to */
-export async function compress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<ArrayBuffer | string> {
-  const byteArray = input instanceof ArrayBuffer
+/** Compresses a string or an Uint8Array using the provided {@linkcode compressionFormat} and returns it as a base64 string */
+export async function compress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType?: "string"): Promise<string>
+/** Compresses a string or an Uint8Array using the provided {@linkcode compressionFormat} and returns it as an Uint8Array */
+export async function compress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType: "arrayBuffer"): Promise<Uint8Array>
+/** Compresses a string or an Uint8Array using the provided {@linkcode compressionFormat} and returns it as a base64 string or Uint8Array, depending on what {@linkcode outputType} is set to */
+export async function compress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<Uint8Array | string> {
+  const byteArray = input instanceof Uint8Array
     ? input
     : new TextEncoder().encode(input?.toString() ?? String(input));
   const comp = new CompressionStream(compressionFormat);
   const writer = comp.writable.getWriter();
   writer.write(byteArray);
   writer.close();
-  const buf = await (new Response(comp.readable).arrayBuffer());
+  const uintArr = new Uint8Array(await (new Response(comp.readable).arrayBuffer()));
   return outputType === "arrayBuffer"
-    ? buf
-    : abtoa(buf);
+    ? uintArr
+    : abtoa(uintArr);
 }
 
-/** Decompresses a previously compressed base64 string or ArrayBuffer, with the format passed by {@linkcode compressionFormat}, converted to a string */
-export async function decompress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType?: "string"): Promise<string>
-/** Decompresses a previously compressed base64 string or ArrayBuffer, with the format passed by {@linkcode compressionFormat}, converted to an ArrayBuffer */
-export async function decompress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType: "arrayBuffer"): Promise<ArrayBuffer>
-/** Decompresses a previously compressed base64 string or ArrayBuffer, with the format passed by {@linkcode compressionFormat}, converted to a string or ArrayBuffer, depending on what {@linkcode outputType} is set to */
-export async function decompress(input: Stringifiable | ArrayBuffer, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<ArrayBuffer | string> {
-  const byteArray = input instanceof ArrayBuffer
+/** Decompresses a previously compressed base64 string or Uint8Array, with the format passed by {@linkcode compressionFormat}, converted to a string */
+export async function decompress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType?: "string"): Promise<string>
+/** Decompresses a previously compressed base64 string or Uint8Array, with the format passed by {@linkcode compressionFormat}, converted to an Uint8Array */
+export async function decompress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType: "arrayBuffer"): Promise<Uint8Array>
+/** Decompresses a previously compressed base64 string or Uint8Array, with the format passed by {@linkcode compressionFormat}, converted to a string or Uint8Array, depending on what {@linkcode outputType} is set to */
+export async function decompress(input: Stringifiable | Uint8Array, compressionFormat: CompressionFormat, outputType: "string" | "arrayBuffer" = "string"): Promise<Uint8Array | string> {
+  const byteArray = input instanceof Uint8Array
     ? input
     : atoab(input?.toString() ?? String(input));
   const decomp = new DecompressionStream(compressionFormat);
   const writer = decomp.writable.getWriter();
   writer.write(byteArray);
   writer.close();
-  const buf = await (new Response(decomp.readable).arrayBuffer());
+  const uintArr = new Uint8Array(await (new Response(decomp.readable).arrayBuffer()));
   return outputType === "arrayBuffer"
-    ? buf
-    : new TextDecoder().decode(buf);
+    ? uintArr
+    : new TextDecoder().decode(uintArr);
 }
 
 /**
- * Creates a hash / checksum of the given {@linkcode input} string or ArrayBuffer using the specified {@linkcode algorithm} ("SHA-256" by default).  
+ * Creates a hash / checksum of the given {@linkcode input} string or Uint8Array using the specified {@linkcode algorithm} ("SHA-256" by default).  
  *   
  * - ⚠️ Uses the SubtleCrypto API so it needs to run in a secure context (HTTPS).  
  * - ⚠️ If you use this for cryptography, make sure to use a secure algorithm (under no circumstances use SHA-1) and to [salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) your input data.
  */
-export async function computeHash(input: string | ArrayBuffer, algorithm = "SHA-256"): Promise<string> {
-  let data: ArrayBuffer;
+export async function computeHash(input: string | Uint8Array, algorithm = "SHA-256"): Promise<string> {
+  let data: Uint8Array;
   if(typeof input === "string") {
     const encoder = new TextEncoder();
     data = encoder.encode(input);

--- a/lib/math.spec.ts
+++ b/lib/math.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bitSetHas, clamp, digitCount, formatNumber, mapRange, randRange, roundFixed, valsWithin } from "./math.js";
+import { bitSetHas, clamp, digitCount, formatNumber, mapRange, overflowVal, randRange, roundFixed, valsWithin } from "./math.js";
 
 //#region clamp
 describe("math/clamp", () => {
@@ -32,6 +32,24 @@ describe("math/mapRange", () => {
     expect(mapRange(0, 0, 0)).toBe(NaN);
     expect(mapRange(Infinity, 10, 1000)).toBe(Infinity);
     expect(mapRange(-Infinity, -Infinity, Infinity)).toBe(NaN);
+  });
+});
+
+//#region overflowVal
+describe("math/overflowVal", () => {
+  it("Overflows a value to be within a range", () => {
+    expect(overflowVal(5, 0, 10)).toBe(5);
+    expect(overflowVal(15, 0, 10)).toBe(4);
+    expect(overflowVal(-5, 0, 10)).toBe(6);
+    expect(overflowVal(3, 2)).toBe(0);
+  });
+
+  it("Handles edge cases", () => {
+    expect(overflowVal(NaN, 10)).toBeNaN();
+    expect(overflowVal(5, 10, NaN)).toBeNaN();
+    expect(overflowVal(Infinity, 10)).toBeNaN();
+    expect(overflowVal(-Infinity, 10)).toBeNaN();
+    expect(() => overflowVal(5, 10, 0)).toThrow(RangeError);
   });
 });
 

--- a/lib/math.ts
+++ b/lib/math.ts
@@ -98,6 +98,29 @@ export function mapRange(value: number, range1min: number, range1max: number, ra
   return (value - range1min) * ((range2max - range2min) / (range1max - range1min)) + range2min;
 }
 
+/** Makes the {@linkcode value} over- & underflow so it is always between {@linkcode min} and {@linkcode max}, if it's outside the range */
+export function overflowVal(value: number, min: number, max: number): number;
+/** Makes the {@linkcode value} over- & underflow so it is always between `0` and {@linkcode max}, if it's outside the range */
+export function overflowVal(value: number, max: number): number;
+/** Makes the {@linkcode value} over- & underflow so it is always in a certain range */
+export function overflowVal(value: number, minOrMax: number, max?: number): number {
+  const min = typeof max === "number" ? minOrMax : 0;
+  max = typeof max === "number" ? max : minOrMax;
+
+  if(min > max)
+    throw new RangeError("Parameter \"min\" can't be bigger than \"max\"");
+
+  if(isNaN(value) || isNaN(min) || isNaN(max) || !isFinite(value) || !isFinite(min) || !isFinite(max))
+    return NaN;
+
+  if(value >= min && value <= max)
+    return value;
+
+  const range = max - min + 1;
+  const wrappedValue = ((value - min) % range + range) % range + min;
+  return wrappedValue;
+}
+
 /**
  * Returns a random number between {@linkcode min} and {@linkcode max} (inclusive)  
  * Set {@linkcode enhancedEntropy} to true to use `crypto.getRandomValues()` for better cryptographic randomness (this also makes it take longer to generate)

--- a/lib/misc.spec.ts
+++ b/lib/misc.spec.ts
@@ -124,7 +124,7 @@ describe("misc/setImmediateInterval", () => {
     const len = times.length;
     expect(len).toBeLessThanOrEqual(7);
     expect(len).toBeGreaterThanOrEqual(6);
-    expect(times.every(t => t <= 200 && t >= 0)).toBe(true);
+    expect(times.every(t => t <= 202 && t >= 0)).toBe(true);
 
     await new Promise(resolve => setTimeout(resolve, 100)); // wait for another 100 ms to ensure no more calls
     expect(times.length).toEqual(len);

--- a/lib/misc.spec.ts
+++ b/lib/misc.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { consumeGen, consumeStringGen, fetchAdvanced, getListLength, pauseFor, pureObj, setImmediateInterval, setImmediateTimeoutLoop } from "./misc.js";
+import { consumeGen, consumeStringGen, fetchAdvanced, getListLength, pauseFor, pureObj, scheduleExit, setImmediateInterval, setImmediateTimeoutLoop } from "./misc.js";
+import { vi } from "vitest";
 
 //#region pauseFor
 describe("misc/pauseFor", () => {
@@ -149,5 +150,22 @@ describe("misc/setImmediateTimeoutLoop", () => {
     expect(times.length).toBeLessThanOrEqual(3);
     expect(times.length).toBeGreaterThanOrEqual(1);
     expect(times.every(t => t <= 200 && t >= 0)).toBe(true);
+  });
+});
+
+//#region scheduleExit
+describe("misc/scheduleExit", () => {
+  it("Schedules an exit with the specified code", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => void code as never);
+
+    scheduleExit(0);
+    await pauseFor(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    scheduleExit(1);
+    await pauseFor(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
   });
 });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "publish-package": "changeset publish",
     "publish-package-jsr": "pnpm update-jsr-version && npx jsr publish --allow-dirty",
     "check-jsr": "pnpm update-jsr-version && npx jsr publish --allow-dirty --dry-run",
+    "check-npm": "npm publish --dry-run",
     "change": "changeset",
     "test": "vitest",
     "test-coverage": "vitest --coverage"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 onlyBuiltDependencies:
   - esbuild
 packages:
+  - '.'
   - lib/**

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 onlyBuiltDependencies:
   - esbuild
+packages:
+  - lib/**


### PR DESCRIPTION
- [x] Add `overflowVal()` to conform a value to an over- & undeflowing range
- [x] Add `NanoEmitter.onMulti()` to listen to multiple events at once, including conditional callback triggering
- DataStore
	- [x] Add optional abstract method `DataStoreEngine.deleteStorage()` for deleting the data storage container itself. If implemented, it will be called from the method `DataStore.deleteData()`
	- [x] Add `dataStoreOptions` constructor prop to the DataStoreEngine subclasses to enable them to be used standalone.
	- [x] Remove the boolean property `__ds-${id}-enc` from the `DataStore` and `DataStoreEngine` classes.  
Instead, set the key `__ds-${id}-enf` to the encoding format identifier string (or `null` if not specified).  
This will make it possible to switch the encoding format without compatibility issues.  
This functionality is not officially supported yet, but can be achieved manually by calling the storage API methods of `storeInstance.engine`